### PR TITLE
feat/parallel-ingestion

### DIFF
--- a/README.md
+++ b/README.md
@@ -714,7 +714,11 @@ pipeline:
     preprocess_enabled: true        
     chunk_enabled: true             
     embedding_enabled: true         
-    save_enabled: true              
+    save_enabled: true
+    # Parallelization settings
+    parallel_enabled: false         # Enable parallel processing of multiple files
+    max_workers: null               # Max parallel workers (null = CPU count, 1 = sequential)
+    executor_type: thread           # Executor type: 'thread' (I/O-bound) or 'process' (CPU-bound)
   
   query:
     retrieve_enabled: true          
@@ -747,6 +751,50 @@ The ingestion pipeline consists of four configurable steps:
    - If disabled: Processing happens but data is not saved (useful for testing)
 
 **Note**: The save step includes embedding generation because embeddings are only useful when stored in the vector database. The embedding model and vector store are only created if `save_enabled` is true
+
+### Parallel Ingestion
+
+The ingestion pipeline supports parallel processing of multiple files to improve throughput when ingesting large batches of documents. Parallelization can significantly reduce total ingestion time, especially when processing many files.
+
+**Configuration Parameters:**
+
+1. **`parallel_enabled`** (default: `false`)
+   - Enables parallel processing of files
+   - When `false`: Files are processed sequentially (one at a time)
+   - When `true`: Multiple files are processed concurrently using thread or process pools
+
+2. **`max_workers`** (default: `null`)
+   - Maximum number of parallel workers
+   - `null`: Uses the number of CPU cores available
+   - `1`: Equivalent to sequential processing (parallel_enabled=false)
+   - `> 1`: Specified number of parallel workers
+   - Recommended: Start with `null` and adjust based on your system resources
+
+3. **`executor_type`** (default: `"thread"`)
+   - Type of executor for parallel processing
+   - `"thread"`: ThreadPoolExecutor - best for I/O-bound tasks (API calls, file reading)
+   - `"process"`: ProcessPoolExecutor - best for CPU-bound tasks (heavy computation)
+   - Recommended: Use `"thread"` for most cases as ingestion involves API calls and I/O operations
+
+**Example Configuration:**
+
+```yaml
+pipeline:
+  ingestion:
+    load_enabled: true
+    preprocess_enabled: true
+    chunk_enabled: true
+    save_enabled: true
+    parallel_enabled: true          # Enable parallel processing
+    max_workers: 4                  # Use 4 parallel workers
+    executor_type: thread           # Use thread-based executor
+```
+
+**Considerations:**
+- Ensure your vector store supports concurrent writes (most do)
+- Monitor system resources when processing many large files
+- API rate limits may affect parallel processing with external services
+- Start with fewer workers and scale up as needed
 
 ### Query Pipeline Steps
 
@@ -824,6 +872,23 @@ pipeline:
 
 **Result**: LLM generates responses without retrieving documents from the database. Useful for general knowledge questions or when you want the LLM to answer without specific context.
 
+#### Use Case 5: High-Volume Parallel Ingestion
+
+Process large batches of documents quickly using parallel processing:
+
+```yaml
+pipeline:
+  ingestion:
+    load_enabled: true
+    preprocess_enabled: true
+    chunk_enabled: true
+    save_enabled: true
+    parallel_enabled: true        # Enable parallel processing
+    max_workers: null             # Use all available CPU cores
+    executor_type: thread         # Thread-based for I/O operations
+```
+
+**Result**: Multiple files are processed concurrently, significantly reducing total ingestion time. The executor automatically manages worker threads and provides progress tracking. Failed files are reported at the end without stopping the entire batch.
 
 ## How to Add New Components
 

--- a/config-example.yaml
+++ b/config-example.yaml
@@ -101,7 +101,11 @@ pipeline:
     load_enabled: true              
     preprocess_enabled: true        
     chunk_enabled: true             
-    save_enabled: true              
+    save_enabled: true
+    # Parallelization settings for processing multiple files
+    parallel_enabled: false         # Enable parallel processing (default: false)
+    max_workers: null               # Max parallel workers (null = CPU count, 1 = sequential)
+    executor_type: thread           # Executor type: 'thread' (I/O-bound) or 'process' (CPU-bound)
   
   query:
     retrieve_enabled: true          

--- a/src/cli/ingest.py
+++ b/src/cli/ingest.py
@@ -3,6 +3,7 @@
 
 import logging
 import sys
+import time
 from pathlib import Path
 from typing import Optional
 
@@ -21,6 +22,8 @@ from src.cli.constants import (
     SEPARATOR_CHAR,
     SEPARATOR_LENGTH,
 )
+from src.cli.models import IngestionResult
+from src.cli.parallel_ingestor import ParallelIngestor
 from src.loaders.constants import SUPPORTED_FILE_EXTENSIONS
 from src.loaders.helpers import LoaderHelper
 from src.logger import Logger
@@ -117,7 +120,7 @@ def ingest_file(
     embedding_model: Optional[Embeddings],
     vector_store: Optional[VectorStore],
     access_tags: Optional[list[str]] = None,
-) -> None:
+) -> IngestionResult:
     """Ingest a media file into the vector database using the pipeline pattern.
 
     Parameters
@@ -132,6 +135,11 @@ def ingest_file(
         Vector store instance (can be None if save step is disabled).
     access_tags
         Optional list of access control tags for the document.
+
+    Returns
+    -------
+    IngestionResult
+        Result object containing success status, chunks count, and any errors.
     """
     logger = logging.getLogger(__name__)
     logger.info(SEPARATOR_CHAR * SEPARATOR_LENGTH)
@@ -153,7 +161,11 @@ def ingest_file(
     context = executor.execute(context)
 
     if context.status == PipelineStatus.FAILED:
-        raise RuntimeError(f"Pipeline failed: {context.error}")
+        return IngestionResult(
+            file_path=file_path,
+            success=False,
+            error=context.error,
+        )
 
     logger.info("\n" + SEPARATOR_CHAR * SEPARATOR_LENGTH)
     logger.info("Ingestion Complete!")
@@ -163,6 +175,125 @@ def ingest_file(
         logger.info(f"✓ Markdown file: {context.markdown_path}")
     logger.info(f"✓ Chunks created: {len(context.chunks)}")
     logger.info(SEPARATOR_CHAR * SEPARATOR_LENGTH + "\n")
+
+    return IngestionResult(
+        file_path=file_path,
+        success=True,
+        chunks_count=len(context.chunks),
+        markdown_path=context.markdown_path,
+    )
+
+
+def _process_files_parallel(
+    media_files: list[Path],
+    config: Config,
+    embedding_model: Optional[Embeddings],
+    vector_store: Optional[VectorStore],
+    access_tags: Optional[list[str]],
+) -> bool:
+    """Process files in parallel.
+
+    Parameters
+    ----------
+    media_files
+        List of media files to process.
+    config
+        Configuration object.
+    embedding_model
+        Embedding model instance.
+    vector_store
+        Vector store instance.
+    access_tags
+        Optional access control tags.
+
+    Returns
+    -------
+    bool
+        True if all files processed successfully, False otherwise.
+    """
+    logger = logging.getLogger(__name__)
+    logger.info("Parallel processing enabled")
+
+    pipeline_config = config.pipeline.ingestion
+    parallel_ingestor = ParallelIngestor(
+        max_workers=pipeline_config.max_workers,
+        executor_type=pipeline_config.executor_type,
+    )
+
+    results = parallel_ingestor.execute(
+        files=media_files,
+        task_fn=ingest_file,
+        task_args={
+            "config": config,
+            "embedding_model": embedding_model,
+            "vector_store": vector_store,
+            "access_tags": access_tags,
+        },
+    )
+
+    parallel_ingestor.log_summary(results)
+
+    if results["failed"]:
+        logger.error(f"✗ {len(results['failed'])} file(s) failed to process")
+        return False
+
+    logger.info("✓ All files processed successfully.")
+    return True
+
+
+def _process_files_sequential(
+    media_files: list[Path],
+    config: Config,
+    embedding_model: Optional[Embeddings],
+    vector_store: Optional[VectorStore],
+    access_tags: Optional[list[str]],
+) -> bool:
+    """Process files sequentially.
+
+    Parameters
+    ----------
+    media_files
+        List of media files to process.
+    config
+        Configuration object.
+    embedding_model
+        Embedding model instance.
+    vector_store
+        Vector store instance.
+    access_tags
+        Optional access control tags.
+
+    Returns
+    -------
+    bool
+        True if all files processed successfully, False otherwise.
+    """
+    logger = logging.getLogger(__name__)
+    logger.info("Sequential processing (parallel disabled)")
+
+    failed_files = []
+
+    for media_file in media_files:
+        result = ingest_file(
+            media_file,
+            config,
+            embedding_model,
+            vector_store,
+            access_tags=access_tags if access_tags else None,
+        )
+
+        if not result.success:
+            failed_files.append((media_file, result.error))
+
+    if failed_files:
+        logger.error("\nFailed files:")
+        for file_path, error in failed_files:
+            logger.error(f"  - {file_path.name}: {error}")
+        logger.error(f"\n✗ {len(failed_files)} file(s) failed to process")
+        return False
+
+    logger.info("✓ All files processed successfully.")
+    return True
 
 
 def main():
@@ -225,16 +356,22 @@ def main():
                 **store_config,
             )
 
-        for media_file in media_files:
-            ingest_file(
-                media_file,
-                config,
-                embedding_model,
-                vector_store,
-                access_tags=access_tags if access_tags else None,
-            )
+        # Process files in parallel if enabled, otherwise sequentially
+        start_time = time.time()
+        process_fn = _process_files_parallel if pipeline_config.parallel_enabled else _process_files_sequential
+        process_fn(
+            media_files,
+            config,
+            embedding_model,
+            vector_store,
+            access_tags,
+        )
+        elapsed_time = time.time() - start_time
 
-        logger.info("✓ All files processed successfully.")
+        logger.info("\n" + SEPARATOR_CHAR * SEPARATOR_LENGTH)
+        logger.info("Ingestion complete!")
+        logger.info(f"Total time: {elapsed_time:.2f} seconds ({elapsed_time/60:.2f} minutes)")
+        logger.info(f"{len(media_files)} file(s) processed successfully")
 
     except Exception as exc:
         logger.error(f"\n✗ Error during ingestion: {exc}", exc_info=True)

--- a/src/cli/models.py
+++ b/src/cli/models.py
@@ -1,0 +1,46 @@
+"""Types and result classes for CLI operations."""
+
+from enum import Enum
+from pathlib import Path
+from typing import Optional
+
+
+class ExecutorType(str, Enum):
+    """Type of executor for parallel processing."""
+
+    THREAD = "thread"
+    PROCESS = "process"
+
+
+class IngestionResult:
+    """Result of a single file ingestion."""
+
+    def __init__(
+        self,
+        file_path: Path,
+        success: bool,
+        error: Optional[str] = None,
+        chunks_count: int = 0,
+        markdown_path: Optional[Path] = None,
+    ):
+        """Initialize the ingestion result.
+
+        Parameters
+        ----------
+        file_path
+            Path to the ingested file.
+        success
+            Whether the ingestion was successful.
+        error
+            Error message if ingestion failed.
+        chunks_count
+            Number of chunks created.
+        markdown_path
+            Path to the generated markdown file.
+        """
+        self.file_path = file_path
+        self.success = success
+        self.error = error
+        self.chunks_count = chunks_count
+        self.markdown_path = markdown_path
+

--- a/src/cli/parallel_ingestor.py
+++ b/src/cli/parallel_ingestor.py
@@ -1,0 +1,144 @@
+"""Parallel ingestor for processing multiple files concurrently."""
+
+import logging
+import os
+from concurrent.futures import Future, ProcessPoolExecutor, ThreadPoolExecutor, as_completed
+from pathlib import Path
+from typing import Any, Callable, Optional
+
+from src.cli.constants import SEPARATOR_CHAR, SEPARATOR_LENGTH
+from src.cli.models import ExecutorType, IngestionResult
+
+
+class ParallelIngestor:
+    """Ingests multiple files in parallel using thread or process pools.
+
+    This ingestor allows processing multiple files concurrently to improve
+    throughput when ingesting large batches of documents.
+    """
+
+    def __init__(
+        self,
+        max_workers: Optional[int] = None,
+        executor_type: ExecutorType = ExecutorType.THREAD,
+    ):
+        """Initialize the parallel ingestor.
+
+        Parameters
+        ----------
+        max_workers
+            Maximum number of parallel workers. If None, uses the number of CPUs.
+        executor_type
+            Type of executor to use (thread or process)
+        """
+        self.max_workers = max_workers
+        self.executor_type = executor_type if isinstance(executor_type, ExecutorType) else ExecutorType(executor_type)
+        self.logger = logging.getLogger(__name__)
+
+    def execute(
+        self,
+        files: list[Path],
+        task_fn: Callable[[Path, Any], IngestionResult],
+        task_args: dict[str, Any],
+    ) -> dict[str, list[IngestionResult]]:
+        """Execute ingestion tasks in parallel.
+
+        Parameters
+        ----------
+        files
+            List of file paths to process.
+        task_fn
+            Function to execute for each file. Should accept (file_path, **task_args)
+            and return an IngestionResult.
+        task_args
+            Additional arguments to pass to the task function.
+
+        Returns
+        -------
+        dict with 'successful' and 'failed' lists of IngestionResult objects.
+        """
+        if not files:
+            self.logger.warning("No files to process")
+            return {"successful": [], "failed": []}
+
+        executor_class = ThreadPoolExecutor if self.executor_type == ExecutorType.THREAD else ProcessPoolExecutor
+
+        # Determine actual number of workers that will be used
+        cpu_count = os.cpu_count() or 1
+        actual_workers = self.max_workers if self.max_workers is not None else cpu_count
+
+        self.logger.info(
+            f"Processing {len(files)} files in parallel using {executor_class.__name__}"
+        )
+        self.logger.info(f"CPU cores available: {cpu_count}")
+        self.logger.info(f"Workers to use: {actual_workers}")
+
+        results = {"successful": [], "failed": []}
+        futures: dict[Future, Path] = {}
+
+        with executor_class(max_workers=self.max_workers) as executor:
+            # Submit all tasks
+            for file_path in files:
+                future = executor.submit(task_fn, file_path, **task_args)
+                futures[future] = file_path
+
+            # Process completed tasks as they finish
+            total = len(files)
+
+            for completed, future in enumerate(as_completed(futures), start=1):
+                file_path = futures[future]
+
+                try:
+                    result = future.result()
+                    if result.success:
+                        results["successful"].append(result)
+                        self.logger.info(
+                            f"[{completed}/{total}] ✓ Successfully processed: {file_path.name}"
+                        )
+                    else:
+                        results["failed"].append(result)
+                        self.logger.error(
+                            f"[{completed}/{total}] ✗ Failed to process: {file_path.name} - {result.error}"
+                        )
+                except Exception as e:
+                    self.logger.info(f"[{completed}/{total}] ✗ Exception processing {file_path}")
+                    results["failed"].append(
+                        IngestionResult(
+                            file_path=file_path,
+                            success=False,
+                            error=str(e),
+                        )
+                    )
+
+        return results
+
+    def log_summary(self, results: dict[str, list[IngestionResult]]) -> None:
+        """Log a summary of the ingestion results.
+
+        Parameters
+        ----------
+        results
+            Dictionary with 'successful' and 'failed' lists of results.
+        """
+        successful = results["successful"]
+        failed = results["failed"]
+        total = len(successful) + len(failed)
+
+        self.logger.info("\n" + SEPARATOR_CHAR * SEPARATOR_LENGTH)
+        self.logger.info("Ingestion Summary")
+        self.logger.info(SEPARATOR_CHAR * SEPARATOR_LENGTH)
+        self.logger.info(f"Total files: {total}")
+        self.logger.info(f"✓ Successful: {len(successful)}")
+        self.logger.info(f"✗ Failed: {len(failed)}")
+
+        if successful:
+            total_chunks = sum(r.chunks_count for r in successful)
+            self.logger.info(f"Total chunks created: {total_chunks}")
+
+        if failed:
+            self.logger.info("\nFailed files:")
+            for result in failed:
+                self.logger.info(f"  - {result.file_path.name}: {result.error}")
+
+        self.logger.info(SEPARATOR_CHAR * SEPARATOR_LENGTH + "\n")
+

--- a/src/config/pipeline.py
+++ b/src/config/pipeline.py
@@ -4,6 +4,8 @@ from typing import Optional
 
 from pydantic import BaseModel, Field
 
+from src.cli.models import ExecutorType
+
 
 class IngestionPipelineConfig(BaseModel):
     """Configuration for ingestion pipeline steps.
@@ -26,6 +28,18 @@ class IngestionPipelineConfig(BaseModel):
     save_enabled: bool = Field(
         default=True,
         description="Enable/disable the save step (includes embedding generation and vector database storage)",
+    )
+    parallel_enabled: bool = Field(
+        default=False,
+        description="Enable/disable parallel processing of multiple files",
+    )
+    max_workers: Optional[int] = Field(
+        default=None,
+        description="Maximum number of parallel workers (None = CPU count, 1 = sequential)",
+    )
+    executor_type: ExecutorType = Field(
+        default=ExecutorType.THREAD,
+        description="Type of executor: 'thread' for I/O-bound tasks, 'process' for CPU-bound tasks",
     )
 
 


### PR DESCRIPTION
# Feat: Add Parallel Ingestion Support

## Summary

Solves https://github.com/qualabs/SMPTE-Copilot/issues/42

This PR introduces parallel processing capabilities to the ingestion pipeline, enabling concurrent processing of multiple files to significantly improve throughput when ingesting large batches of documents.

## Changes

### New Features

- **Parallel File Processing**: Files can now be processed concurrently using thread or process pools
- **Configurable Workers**: Control the number of parallel workers (defaults to CPU count)
- **Flexible Executor Types**: Choose between thread-based (I/O-bound) or process-based (CPU-bound) executors
- **Progress Tracking**: Real-time progress updates showing `[completed/total]` status for each file
- **Enhanced Error Handling**: Failed files are tracked and reported without stopping the entire batch

### New Files

1. **`src/cli/parallel_ingestor.py`** (144 lines)
   - `ParallelIngestor` class implementing concurrent file processing
   - Supports both `ThreadPoolExecutor` and `ProcessPoolExecutor`
   - Provides detailed logging and summary reports

2. **`src/cli/models.py`** (46 lines)
   - `IngestionResult` dataclass for tracking individual file ingestion results
   - `ExecutorType` enum for defining executor types (`thread` or `process`)

### Modified Files

1. **`src/cli/ingest.py`**
   - Refactored `ingest_file()` to return `IngestionResult` instead of raising exceptions
   - Added `_process_files_parallel()` for parallel processing workflow
   - Added `_process_files_sequential()` for sequential processing workflow
   - Updated `main()` to support both processing modes with execution time tracking

2. **`src/config/pipeline.py`**
   - Added three new configuration fields to `IngestionPipelineConfig`:
     - `parallel_enabled`: Boolean flag to enable/disable parallel processing
     - `max_workers`: Optional integer to control number of workers
     - `executor_type`: Enum to choose between thread and process executors

3. **`config-example.yaml`**
   - Added parallel processing configuration section with defaults and comments