### PR TITLE
Hotfix/access-tags-metadata

### DIFF
--- a/src/loaders/docling_loader.py
+++ b/src/loaders/docling_loader.py
@@ -117,6 +117,8 @@ class DoclingLoader(DocumentLoader):
                 metadata["creation_date"] = str(doc_meta.creation_date)
             if hasattr(doc_meta, "modification_date") and doc_meta.modification_date:
                 metadata["modification_date"] = str(doc_meta.modification_date)
+            if hasattr(doc_meta, "access_tags") and doc_meta.access_tags:
+                metadata["access_tags"] = doc_meta.access_tags
 
         return [
             Document(

--- a/src/pipeline/steps/load_step.py
+++ b/src/pipeline/steps/load_step.py
@@ -37,6 +37,10 @@ class LoadStep:
         if loaded_docs:
             context.metadata = loaded_docs[0].metadata.copy()
 
+            # Inject default access_tags if not present in document metadata
+            if "access_tags" not in context.metadata and context.access_tags:
+                context.metadata["access_tags"] = context.access_tags
+
         md_text = self.loader.to_markdown_text()
         context.raw_text = md_text
 

--- a/src/pipeline/steps/save_step.py
+++ b/src/pipeline/steps/save_step.py
@@ -23,25 +23,6 @@ class SaveStep:
         """
         self.vector_store = vector_store
 
-    def _inject_access_metadata(self, metadata: dict, context: IngestionContext) -> None:
-        """Inject access control metadata into a metadata dictionary.
-
-        Prioritizes file metadata over global config. If metadata already
-        contains access_tags, those are preserved. Otherwise, falls back to context values.
-
-        Parameters
-        ----------
-        metadata
-            Metadata dictionary to update (modified in place).
-        context
-            Ingestion context with access control settings.
-        """
-        if "access_tags" not in metadata and context.access_tags:
-            metadata["access_tags"] = context.access_tags
-
-        if context.access_metadata:
-            metadata.update(context.access_metadata)
-
     def run(self, context: IngestionContext) -> None:
         """Save chunks with embeddings to the vector store.
 
@@ -71,9 +52,6 @@ class SaveStep:
                 for chunk in context.chunks
             ]
 
-            for metadata in metadatas:
-                self._inject_access_metadata(metadata, context)
-
             file_path_str = str(context.file_path.resolve())
             file_hash_bytes = hashlib.md5(file_path_str.encode()).digest()
             file_hash = int.from_bytes(file_hash_bytes[:8], byteorder='big', signed=False)
@@ -86,9 +64,6 @@ class SaveStep:
                 ids=ids,
             )
         else:
-            for chunk in context.chunks:
-                self._inject_access_metadata(chunk.metadata, context)
-
             self.vector_store.add_documents(context.chunks)
 
         self.vector_store.persist()


### PR DESCRIPTION
## Summary

Add support for extracting `access_tags` from document metadata in DoclingLoader.

## Description

This PR enhances the DoclingLoader to automatically extract `access_tags` from document metadata if present in the source document. This allows documents to carry their own access control tags through the ingestion pipeline, enabling more granular access control without manual tag assignment.