### PR TITLE
upgrade to use python 3.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for RAG Ingestion & Retrieval Pipeline
-FROM python:3.9-slim
+FROM python:3.12-slim
 
 # Set working directory
 WORKDIR /app

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,9 +3,10 @@ name = "rag-ingestion"
 version = "0.1.0"
 description = "Utilities for ingesting PDFs into a RAG pipeline."
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [
-  "langchain>=0.3.0",
+  "langchain-core>=0.3.0",
+  "langchain-text-splitters>=0.3.0",
   "langchain-community>=0.3.0",
   "langchain-openai>=0.1.0",
   "pymupdf>=1.24.9",
@@ -50,7 +51,7 @@ where = ["src"]
 [tool.ruff]
 # Line length matching the project style
 line-length = 100
-target-version = "py39"
+target-version = "py312"
 
 # Exclude common directories
 exclude = [
@@ -81,7 +82,6 @@ ignore = [
     "TRY300", # Consider moving statement to else block (prefer early return pattern)
     "PLW0603", # Using global statement (needed for singleton pattern)
     "PLW0602", # Using global for lock (needed for singleton pattern)
-    "UP045", # Prefer Optional[X] over X | None (required for Python 3.9 compatibility)
 ]
 
 # Enable specific rule sets

--- a/src/chunkers/hybrid_chunker.py
+++ b/src/chunkers/hybrid_chunker.py
@@ -4,11 +4,11 @@ from __future__ import annotations
 import logging
 import tempfile
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any
 
 from docling.chunking import HybridChunker as DoclingHybridChunker
 from docling.document_converter import DocumentConverter
-from langchain.schema import Document
+from langchain_core.documents import Document
 
 from ..constants import DEFAULT_ENCODING
 from .protocol import Chunker
@@ -26,7 +26,7 @@ class HybridChunker:
         self,
         max_tokens: int = 2000,
         merge_peers: bool = False,
-        tokenizer: Optional[Tokenizer] = None,
+        tokenizer: Tokenizer | None = None,
     ):
         """Initialize the hybrid chunker.
 
@@ -107,7 +107,7 @@ class HybridChunker:
 
         return documents
 
-    def chunk_text(self, text: str, metadata: Optional[dict] = None) -> list[Document]:
+    def chunk_text(self, text: str, metadata: dict | None = None) -> list[Document]:
         """Chunk text using hybrid chunking strategy.
 
         Parameters

--- a/src/chunkers/langchain_chunker.py
+++ b/src/chunkers/langchain_chunker.py
@@ -3,10 +3,10 @@ from __future__ import annotations
 """LangChain-based chunker implementation."""
 import logging
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any
 
-from langchain.schema import Document
-from langchain.text_splitter import (
+from langchain_core.documents import Document
+from langchain_text_splitters import (
     CharacterTextSplitter,
     RecursiveCharacterTextSplitter,
     TokenTextSplitter,
@@ -97,7 +97,7 @@ class LangChainChunker:
             **extra_kwargs
         )
 
-    def chunk_text(self, text: str, metadata: Optional[dict] = None) -> list[Document]:
+    def chunk_text(self, text: str, metadata: dict | None = None) -> list[Document]:
         """Chunk a markdown text string into LangChain Documents."""
         if not text or not text.strip():
             return []

--- a/src/chunkers/protocol.py
+++ b/src/chunkers/protocol.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 """Protocol for chunker implementations."""
 
-from typing import Optional, Protocol
+from typing import Protocol
 
-from langchain.schema import Document
+from langchain_core.documents import Document
 
 from ..constants import DEFAULT_ENCODING
 
@@ -17,7 +17,7 @@ class Chunker(Protocol):
     This allows swapping chunking algorithms without changing the rest of the code.
     """
 
-    def chunk_text(self, text: str, metadata: Optional[dict] = None) -> list[Document]:
+    def chunk_text(self, text: str, metadata: dict | None = None) -> list[Document]:
         """Chunk a text string into Document objects."""
         ...
 

--- a/src/loaders/docling_loader.py
+++ b/src/loaders/docling_loader.py
@@ -1,7 +1,7 @@
 
 from collections.abc import Sequence
 from pathlib import Path
-from typing import Any, Union
+from typing import Any
 
 from docling.datamodel.base_models import InputFormat
 from docling.datamodel.pipeline_options import (
@@ -17,13 +17,13 @@ from docling.document_converter import (
     PdfFormatOption,
     WordFormatOption,
 )
-from langchain.schema import Document
+from langchain_core.documents import Document
 
 from src.constants import DEFAULT_IMAGE_DESCRIPTION_PROMPT, DEFAULT_IMAGE_DESCRIPTION_TIMEOUT
 
 from .protocol import DocumentLoader
 
-PageSpecifier = Union[Sequence[int], range, None]
+PageSpecifier = Sequence[int] | range | None
 
 class DoclingLoader(DocumentLoader):
     def __init__(self, config: dict[str, Any]) -> None:

--- a/src/loaders/protocol.py
+++ b/src/loaders/protocol.py
@@ -4,13 +4,13 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 from pathlib import Path
-from typing import Optional, Protocol, Union
+from typing import Protocol
 
-from langchain.schema import Document
+from langchain_core.documents import Document
 
 from ..constants import DEFAULT_ENCODING
 
-PageSpecifier = Union[Sequence[int], range, None]
+PageSpecifier = Sequence[int] | range | None
 
 
 class DocumentLoader(Protocol):
@@ -35,9 +35,9 @@ class DocumentLoader(Protocol):
         self,
         *,
         pages: PageSpecifier = None,
-        output_path: Optional[Path] = None,
+        output_path: Path | None = None,
         overwrite: bool = True,
-        md_text: Optional[str] = None,
+        md_text: str | None = None,
     ) -> Path:
         """Save the document as a Markdown file.
 
@@ -60,7 +60,7 @@ class DocumentLoader(Protocol):
         destination.write_text(md_text, encoding=DEFAULT_ENCODING)
         return destination
 
-    def _resolve_output_path(self, output_path: Optional[Path]) -> Path:
+    def _resolve_output_path(self, output_path: Path | None) -> Path:
         """Resolve the output path for the markdown file.
 
         Parameters

--- a/src/loaders/pymupdf_loader.py
+++ b/src/loaders/pymupdf_loader.py
@@ -4,15 +4,15 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 from pathlib import Path
-from typing import Any, Union
+from typing import Any
 
 import pymupdf4llm
-from langchain.schema import Document
 from langchain_community.document_loaders import PyMuPDFLoader as LangChainPyMuPDFLoader
+from langchain_core.documents import Document
 
 from .protocol import DocumentLoader
 
-PageSpecifier = Union[Sequence[int], range, None]
+PageSpecifier = Sequence[int] | range | None
 
 
 class PyMuPDFLoader(DocumentLoader):

--- a/src/loaders/whisper_loader.py
+++ b/src/loaders/whisper_loader.py
@@ -5,14 +5,14 @@ from __future__ import annotations
 import logging
 from collections.abc import Sequence
 from pathlib import Path
-from typing import Any, Optional, Union
+from typing import Any
 
 import whisper
-from langchain.schema import Document
+from langchain_core.documents import Document
 
 from .protocol import DocumentLoader
 
-PageSpecifier = Union[Sequence[int], range, None]
+PageSpecifier = Sequence[int] | range | None
 
 
 class WhisperLoader(DocumentLoader):
@@ -61,7 +61,7 @@ class WhisperLoader(DocumentLoader):
         self.language = config.get("language", "en")
         self.include_timestamps = config.get("include_timestamps", True)
 
-        self._model: Optional[whisper.Whisper] = None
+        self._model: whisper.Whisper | None = None
 
     def _load_model(self) -> whisper.Whisper:
         """Load the Whisper model (lazy loading).

--- a/src/pipeline/contexts/ingestion_context.py
+++ b/src/pipeline/contexts/ingestion_context.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 """Context for document ingestion pipeline."""
 
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any
 
-from langchain.schema import Document
+from langchain_core.documents import Document
 from pydantic import Field
 
 from ..context import PipelineContext
@@ -19,8 +19,8 @@ class IngestionContext(PipelineContext):
     """
 
     file_path: Path
-    raw_text: Optional[str] = None
-    markdown_path: Optional[Path] = None
+    raw_text: str | None = None
+    markdown_path: Path | None = None
     chunks: list[Document] = Field(default_factory=list)
     vectors: list[list[float]] = Field(default_factory=list)
     metadata: dict[str, Any] = Field(default_factory=dict)  # Metadata extracted from the loaded document

--- a/src/pipeline/contexts/query_context.py
+++ b/src/pipeline/contexts/query_context.py
@@ -3,9 +3,8 @@ from __future__ import annotations
 """Context for query pipeline."""
 
 
-from typing import Optional
 
-from langchain.schema import Document
+from langchain_core.documents import Document
 from pydantic import Field
 
 from ..context import PipelineContext
@@ -19,13 +18,13 @@ class QueryContext(PipelineContext):
     """
 
     user_query: str
-    query_vector: Optional[list[float]] = None
+    query_vector: list[float] | None = None
     retrieved_docs: list[tuple[Document, float]] = Field(default_factory=list)
-    prompt: Optional[str] = None
-    llm_response: Optional[str] = None
-    citations: Optional[list[dict]] = None
+    prompt: str | None = None
+    llm_response: str | None = None
+    citations: list[dict] | None = None
 
     # Roles are automatically converted to tags via role_mapping
-    user_role: Optional[str] = None
-    role_mapping: Optional[dict[str, list[str]]] = None  # Role-to-tags mapping
+    user_role: str | None = None
+    role_mapping: dict[str, list[str]] | None = None  # Role-to-tags mapping
 

--- a/src/pipeline/steps/answer_generation_step.py
+++ b/src/pipeline/steps/answer_generation_step.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 
-from langchain.schema import Document
+from langchain_core.documents import Document
 
 from ...llms.protocol import LLM
 from ..contexts.query_context import QueryContext

--- a/src/pipeline/steps/embedding_generation_step.py
+++ b/src/pipeline/steps/embedding_generation_step.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 
-from langchain.schema import Document
+from langchain_core.documents import Document
 
 from ...embeddings.constants import EMBEDDING_METADATA_KEY, EMBEDDING_MODEL_METADATA_KEY
 from ...embeddings.protocol import Embeddings
@@ -47,7 +47,7 @@ class EmbeddingGenerationStep:
         embeddings = self.embedding_model.embed_documents(texts)
 
         embedded_chunks = []
-        for chunk, embedding in zip(context.chunks, embeddings):
+        for chunk, embedding in zip(context.chunks, embeddings, strict=False):
             embedded_chunk = Document(
                 page_content=chunk.page_content,
                 metadata={

--- a/src/retrievers/protocol.py
+++ b/src/retrievers/protocol.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 """Protocol for retriever implementations."""
 
-from typing import Any, Optional, Protocol
+from typing import Any, Protocol
 
-from langchain.schema import Document
+from langchain_core.documents import Document
 
 
 class Retriever(Protocol):
@@ -22,7 +22,7 @@ class Retriever(Protocol):
         """Retrieve documents with similarity scores."""
         ...
 
-    def set_filter(self, filter: Optional[Any]) -> None:
+    def set_filter(self, filter: Any | None) -> None:
         """Set the metadata filter for retrieval.
 
         Parameters

--- a/src/retrievers/similarity_retriever.py
+++ b/src/retrievers/similarity_retriever.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 """Similarity search retriever implementation."""
 
-from typing import Any, Optional
+from typing import Any
 
-from langchain.schema import Document
+from langchain_core.documents import Document
 
 from ..constants import DEFAULT_RETRIEVAL_K
 from ..vector_stores.protocol import VectorStore
@@ -36,7 +36,7 @@ class DocumentRetriever:
         self.k = k
         self.metadata_filter: Any = None
 
-    def set_filter(self, filter: Optional[Any]) -> None:
+    def set_filter(self, filter: Any | None) -> None:
         """Set the metadata filter for retrieval.
 
         Parameters

--- a/src/vector_stores/chromadb.py
+++ b/src/vector_stores/chromadb.py
@@ -3,10 +3,10 @@ from __future__ import annotations
 """ChromaDB vector store implementation."""
 
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any
 
-from langchain.schema import Document
 from langchain_community.vectorstores import Chroma
+from langchain_core.documents import Document
 
 from ..constants import DEFAULT_RETRIEVAL_K
 from ..embeddings.protocol import Embeddings
@@ -30,9 +30,9 @@ class ChromaDBWrapper:
     def add_texts(
         self,
         texts: list[str],
-        metadatas: Optional[list[dict[str, Any]]] = None,
-        ids: Optional[list[int]] = None,
-        embeddings: Optional[list[list[float]]] = None,
+        metadatas: list[dict[str, Any]] | None = None,
+        ids: list[int] | None = None,
+        embeddings: list[list[float]] | None = None,
     ) -> None:
         """Add texts to the vector store with pre-computed embeddings.
 
@@ -61,7 +61,7 @@ class ChromaDBWrapper:
         self,
         query: str,
         k: int = DEFAULT_RETRIEVAL_K,
-        filter: Optional[Any] = None,
+        filter: Any | None = None,
     ) -> list[Document]:
         """Search for similar documents.
 
@@ -74,7 +74,7 @@ class ChromaDBWrapper:
         self,
         query: str,
         k: int = DEFAULT_RETRIEVAL_K,
-        filter: Optional[Any] = None,
+        filter: Any | None = None,
     ) -> list[tuple[Document, float]]:
         """Search for similar documents with similarity scores.
 

--- a/src/vector_stores/protocol.py
+++ b/src/vector_stores/protocol.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 """Protocol for vector store implementations."""
 
-from typing import Any, Optional, Protocol
+from typing import Any, Protocol
 
-from langchain.schema import Document
+from langchain_core.documents import Document
 
 from ..constants import DEFAULT_RETRIEVAL_K
 
@@ -22,7 +22,7 @@ class VectorStore(Protocol):
         self,
         query: str,
         k: int = DEFAULT_RETRIEVAL_K,
-        filter: Optional[Any] = None,
+        filter: Any | None = None,
     ) -> list[Document]:
         """Search for similar documents.
 
@@ -41,7 +41,7 @@ class VectorStore(Protocol):
         self,
         query: str,
         k: int = DEFAULT_RETRIEVAL_K,
-        filter: Optional[Any] = None,
+        filter: Any | None = None,
     ) -> list[tuple[Document, float]]:
         """Search for similar documents with similarity scores.
 
@@ -66,9 +66,9 @@ class VectorStore(Protocol):
     def add_texts(
         self,
         texts: list[str],
-        metadatas: Optional[list[dict[str, Any]]] = None,
-        ids: Optional[list[int]] = None,
-        embeddings: Optional[list[list[float]]] = None,
+        metadatas: list[dict[str, Any]] | None = None,
+        ids: list[int] | None = None,
+        embeddings: list[list[float]] | None = None,
     ) -> None:
         """Add texts to the vector store.
 

--- a/src/vector_stores/qdrant.py
+++ b/src/vector_stores/qdrant.py
@@ -2,9 +2,9 @@
 from __future__ import annotations
 
 import logging
-from typing import Any, Optional
+from typing import Any
 
-from langchain.schema import Document
+from langchain_core.documents import Document
 from langchain_qdrant import QdrantVectorStore
 from qdrant_client import QdrantClient
 from qdrant_client.http.exceptions import UnexpectedResponse
@@ -47,9 +47,9 @@ class QdrantVectorStoreWrapper:
     def add_texts(
         self,
         texts: list[str],
-        metadatas: Optional[list[dict[str, Any]]] = None,
-        ids: Optional[list[int]] = None,
-        embeddings: Optional[list[list[float]]] = None,
+        metadatas: list[dict[str, Any]] | None = None,
+        ids: list[int] | None = None,
+        embeddings: list[list[float]] | None = None,
     ) -> None:
         """Add texts to the vector store with pre-computed embeddings.
 
@@ -72,7 +72,7 @@ class QdrantVectorStoreWrapper:
         if metadatas is None:
             metadatas = [{}] * len(texts)
 
-        for doc_id, text, embedding, metadata in zip(ids, texts, embeddings, metadatas):
+        for doc_id, text, embedding, metadata in zip(ids, texts, embeddings, metadatas, strict=False):
             vector = list(embedding)
 
             payload = {"page_content": text, **(metadata or {})}
@@ -100,7 +100,7 @@ class QdrantVectorStoreWrapper:
         self,
         query: str,
         k: int = DEFAULT_RETRIEVAL_K,
-        filter: Optional[Any] = None,
+        filter: Any | None = None,
     ) -> list[Document]:
         """Search for similar documents."""
         self._ensure_collection_exists()
@@ -112,7 +112,7 @@ class QdrantVectorStoreWrapper:
         self,
         query: str,
         k: int = DEFAULT_RETRIEVAL_K,
-        filter: Optional[Any] = None,
+        filter: Any | None = None,
     ) -> list[tuple[Document, float]]:
         """Search for similar documents with similarity scores."""
         self._ensure_collection_exists()


### PR DESCRIPTION
## Summary

This PR modernizes the codebase by upgrading the Python version from 3.9 to 3.12 and adopting Python 3.10+ type annotation syntax throughout the project.

## Changes

### Python Version Upgrade
- **Dockerfile**: Updated base image from `python:3.9-slim` to `python:3.12-slim`
- **pyproject.toml**: Updated minimum Python requirement from `>=3.9` to `>=3.10`
- **Ruff configuration**: Updated target version from `py39` to `py312`

### Dependency Updates
- Split `langchain` dependency into more specific packages:
  - `langchain-core>=0.3.0`
  - `langchain-text-splitters>=0.3.0`
  - `langchain-community>=0.3.0` (already present)
- Updated imports across the codebase from `langchain.schema` to `langchain_core.documents`

### Type Annotation Modernization
Replaced legacy type annotation syntax with modern Python 3.10+ syntax across all protocol files and implementations:
- `Optional[X]` → `X | None`
- `Union[X, Y]` → `X | Y`
- Removed `from typing import Optional, Union` where no longer needed