### PR TITLE
Feat: add support for custom domain in CloudFront configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -220,8 +220,6 @@ config.yaml
 **/.terraform/*
 *.tfstate
 *.tfstate.*
-*.tfvars
-*.tfvars.json
 *.tfplan
 crash.log
 crash.*.log

--- a/infrastructure/.gitignore
+++ b/infrastructure/.gitignore
@@ -13,10 +13,6 @@ smpte-copilot.pub
 crash.log
 crash.*.log
 
-# Exclude all .tfvars files
-*.tfvars
-*.tfvars.json
-
 # Ignore override files
 override.tf
 override.tf.json

--- a/infrastructure/cloudfront.tf
+++ b/infrastructure/cloudfront.tf
@@ -35,6 +35,38 @@ data "aws_ec2_managed_prefix_list" "cloudfront" {
   name = "com.amazonaws.global.cloudfront.origin-facing"
 }
 
+# CloudFront Function to redirect default domain to custom domain
+resource "aws_cloudfront_function" "redirect_to_custom_domain" {
+  count   = var.enable_custom_domain ? 1 : 0
+  name    = "${var.project_name}-redirect-to-custom-domain"
+  runtime = "cloudfront-js-1.0"
+  comment = "Redirect CloudFront default domain to custom domain"
+  publish = true
+  code    = <<-EOT
+    function handler(event) {
+        var request = event.request;
+        var host = request.headers.host.value;
+        
+        // If accessing via CloudFront domain, redirect to custom domain
+        if (host.endsWith('.cloudfront.net')) {
+            var newUrl = 'https://${var.custom_domain_name}' + request.uri;
+            if (request.querystring && request.querystring.value) {
+                newUrl += '?' + request.querystring.value;
+            }
+            return {
+                statusCode: 301,
+                statusDescription: 'Moved Permanently',
+                headers: {
+                    'location': { value: newUrl }
+                }
+            };
+        }
+        
+        return request;
+    }
+  EOT
+}
+
 # CloudFront Distribution for OpenWebUI
 resource "aws_cloudfront_distribution" "openwebui" {
   enabled         = true
@@ -43,7 +75,7 @@ resource "aws_cloudfront_distribution" "openwebui" {
   aliases         = var.enable_custom_domain ? [var.custom_domain_name] : []
 
   origin {
-    domain_name = aws_instance.server.public_dns
+    domain_name = aws_eip.server.public_dns
     origin_id   = "openwebui-ec2-origin"
 
     custom_origin_config {
@@ -62,6 +94,15 @@ resource "aws_cloudfront_distribution" "openwebui" {
 
     cache_policy_id          = data.aws_cloudfront_cache_policy.caching_disabled.id
     origin_request_policy_id = data.aws_cloudfront_origin_request_policy.all_viewer.id
+
+    # Redirect CloudFront domain to custom domain when enabled
+    dynamic "function_association" {
+      for_each = var.enable_custom_domain ? [1] : []
+      content {
+        event_type   = "viewer-request"
+        function_arn = aws_cloudfront_function.redirect_to_custom_domain[0].arn
+      }
+    }
   }
 
   restrictions {

--- a/infrastructure/cloudfront.tf
+++ b/infrastructure/cloudfront.tf
@@ -42,29 +42,9 @@ resource "aws_cloudfront_function" "redirect_to_custom_domain" {
   runtime = "cloudfront-js-1.0"
   comment = "Redirect CloudFront default domain to custom domain"
   publish = true
-  code    = <<-EOT
-    function handler(event) {
-        var request = event.request;
-        var host = request.headers.host.value;
-        
-        // If accessing via CloudFront domain, redirect to custom domain
-        if (host.endsWith('.cloudfront.net')) {
-            var newUrl = 'https://${var.custom_domain_name}' + request.uri;
-            if (request.querystring && request.querystring.value) {
-                newUrl += '?' + request.querystring.value;
-            }
-            return {
-                statusCode: 301,
-                statusDescription: 'Moved Permanently',
-                headers: {
-                    'location': { value: newUrl }
-                }
-            };
-        }
-        
-        return request;
-    }
-  EOT
+  code    = templatefile("${path.module}/redirect_to_custom_domain.js", {
+    custom_domain_name = var.custom_domain_name
+  })
 }
 
 # CloudFront Distribution for OpenWebUI

--- a/infrastructure/compute.tf
+++ b/infrastructure/compute.tf
@@ -67,4 +67,15 @@ resource "aws_instance" "server" {
   })
 }
 
+# Elastic IP for stable DNS
+resource "aws_eip" "server" {
+  domain   = "vpc"
+  instance = aws_instance.server.id
+
+  tags = {
+    Name = "${var.project_name}-server-eip"
+  }
+}
+
+
  

--- a/infrastructure/redirect_to_custom_domain.js
+++ b/infrastructure/redirect_to_custom_domain.js
@@ -1,0 +1,21 @@
+function handler(event) {
+    var request = event.request;
+    var host = request.headers.host.value;
+        
+    // If accessing via CloudFront domain, redirect to custom domain
+    if (host.endsWith('.cloudfront.net')) {
+        var newUrl = 'https://${custom_domain_name}' + request.uri;
+        if (request.querystring && request.querystring.value) {
+            newUrl += '?' + request.querystring.value;
+        }
+        return {
+            statusCode: 301,
+            statusDescription: 'Moved Permanently',
+            headers: {
+                'location': { value: newUrl }
+            }
+        };
+    }
+        
+    return request;
+}

--- a/infrastructure/terraform.tfvars
+++ b/infrastructure/terraform.tfvars
@@ -1,0 +1,4 @@
+aws_profile           = "smpte-copilot"
+ssh_public_key        = "smpte-copilot.pub"
+custom_domain_name    = "smpte-copilot.qualabs.com"
+enable_custom_domain  = true

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -7,7 +7,6 @@ variable "region" {
 variable "aws_profile" {
   description = "AWS CLI/SDK profile to use for provider and CLI snippets"
   type        = string
-  default     = "smpte-copilot"
 }
 
 variable "project_name" {
@@ -43,17 +42,14 @@ variable "repo_url" {
 variable "ssh_public_key" {
   description = "Public SSH key (OpenSSH format) to install on both instances. Example: ssh-ed25519 AAAA... user@host"
   type        = string
-  default     = "smpte-copilot.pub"
 }
 
 variable "custom_domain_name" {
   description = "Custom domain name for CloudFront distribution"
   type        = string
-  default     = "smpte-copilot.qualabs.com"
 }
 
 variable "enable_custom_domain" {
   description = "Enable custom domain for CloudFront distribution. Set to false for first deployment, then true after DNS validation"
   type        = bool
-  default     = false
 }


### PR DESCRIPTION
- Fixes issues with custom domain not working 
- Adds public IP to server so make it easier to connect after restarts and to avoid needing to make changes to cloudfront configuration